### PR TITLE
Fix of OreDictionary matching in `matches` at `itemequality`

### DIFF
--- a/src/main/scala/mrtjp/core/item/itemequality.scala
+++ b/src/main/scala/mrtjp/core/item/itemequality.scala
@@ -12,15 +12,15 @@ class ItemEquality {
   var matchNBT = true
   var matchOre = false
 
-  var damageGroup = -1
+  var damageGroup: Int = -1
 
-  def apply(key: ItemKey) = {
+  def apply(key: ItemKey): AppliedItemEquality = {
     val c = new AppliedItemEquality(key)
     c.setFlags(matchMeta, matchNBT, matchOre, damageGroup)
     c
   }
 
-  def setFlags(meta: Boolean, nbt: Boolean, ore: Boolean, group: Int) {
+  def setFlags(meta: Boolean, nbt: Boolean, ore: Boolean, group: Int): Unit = {
     matchMeta = meta
     matchNBT = nbt
     matchOre = ore
@@ -34,9 +34,9 @@ class ItemEquality {
     val stack2 = key2.makeStack(0)
 
     if (matchOre) {
-      val a = OreDictionary.getOreIDs(stack1)
-      val b = OreDictionary.getOreIDs(stack2)
-      if (a.exists(b.contains)) return true
+      val ids1 = OreDictionary.getOreIDs(stack1)
+      val ids2 = OreDictionary.getOreIDs(stack2)
+      if (ids1.forall(id1 => ids2.contains(id1))) return true
     }
 
     if (key1.item == key2.item) {

--- a/src/main/scala/mrtjp/core/item/itemequality.scala
+++ b/src/main/scala/mrtjp/core/item/itemequality.scala
@@ -27,6 +27,12 @@ class ItemEquality {
     damageGroup = group
   }
 
+  /** Can only match first item with second time due to OreDictionary
+    * @param key1
+    *   Item you want to match
+    * @param key2
+    *   Item with you want to match
+    */
   def matches(key1: ItemKey, key2: ItemKey): Boolean = {
     if (key1 == null || key1 == null) return key1 == key1
 


### PR DESCRIPTION
Fixed the issue when the item was incorrectly matched via OreDictionary

Related PR :
- https://github.com/GTNewHorizons/ProjectRed/pull/37