### PR TITLE
fix thread safety issue in renderWorldBlock

### DIFF
--- a/src/main/scala/mrtjp/core/render/TCubeMapRender.scala
+++ b/src/main/scala/mrtjp/core/render/TCubeMapRender.scala
@@ -40,7 +40,6 @@ trait TCubeMapRender extends TInstancedBlockRender {
       meta: Int
   ) {
     val (s, rot, icon) = getData(w, x, y, z)
-    TextureUtils.bindAtlas(0)
     val state = CCRenderState.instance
     state.resetInstance()
     state.lightMatrix.locate(w, x, y, z)


### PR DESCRIPTION
TextureUtils.bindAtlas during block rendering will crash when using multithreaded Celeritas-based renderers