### PR TITLE
[Memory-opti:fix leak] fix world client leak from light matrix

### DIFF
--- a/src/main/scala/mrtjp/core/render/TCubeMapRender.scala
+++ b/src/main/scala/mrtjp/core/render/TCubeMapRender.scala
@@ -48,6 +48,7 @@ trait TCubeMapRender extends TInstancedBlockRender {
       icon,
       state.lightMatrix
     )
+    state.lightMatrix.access = null
   }
 
   override def renderBreaking(


### PR DESCRIPTION
<img width="468" height="149" alt="image" src="https://github.com/user-attachments/assets/7027aee3-3dd9-4930-aff6-ea9fc006ca22" />
